### PR TITLE
Update delivery_demo.xml

### DIFF
--- a/addons/delivery/data/delivery_demo.xml
+++ b/addons/delivery/data/delivery_demo.xml
@@ -6,7 +6,7 @@
 
         <record id="product_product_delivery_poste" model="product.product">
             <field name="name">The Poste</field>
-            <field name="default_code">Delivery</field>
+            <field name="default_code">Delivery_008</field>
             <field name="type">service</field>
             <field name="categ_id" ref="product.product_category_all"/>
             <field name="sale_ok" eval="False"/>
@@ -24,7 +24,7 @@
 
         <record id="product_product_delivery_normal" model="product.product">
             <field name="name">Normal Delivery Charges</field>
-            <field name="default_code">Delivery</field>
+            <field name="default_code">Delivery_009</field>
             <field name="type">service</field>
             <field name="categ_id" ref="product.product_category_all"/>
             <field name="sale_ok" eval="False"/>


### PR DESCRIPTION
Patch of default code to set them unique

Description of the issue/feature this PR addresses:
Change the default code in demo data of delivery to set them unique

Current behavior before PR:
Break the behaviour of previous install

Desired behavior after PR is merged:
all default code to be unique




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
